### PR TITLE
Add source run flag to check response ID

### DIFF
--- a/rcon/source/client.py
+++ b/rcon/source/client.py
@@ -64,12 +64,12 @@ class Client(BaseClient, socket_type=SOCK_STREAM):
 
         return True
 
-    def run(self, command: str, *args: str, encoding: str = "utf-8") -> str:
+    def run(self, command: str, *args: str, encoding: str = "utf-8", enforce_id: bool = True) -> str:
         """Run a command."""
         request = Packet.make_command(command, *args, encoding=encoding)
         response = self.communicate(request)
 
-        if response.id != request.id:
-            raise SessionTimeout()
+        if enforce_id and response.id != request.id:
+            raise SessionTimeout("packet ID mismatch")
 
         return response.payload.decode(encoding)


### PR DESCRIPTION
Some servers might not follow the Source RCON spec and Palworld is one of them. This flag allows run to ignore the response ID.

conqp/rcon#25