### PR TITLE
Add param to raise error on Unexpected terminator

### DIFF
--- a/rcon/client.py
+++ b/rcon/client.py
@@ -39,7 +39,7 @@ class BaseClient:
         return self._socket.__exit__(typ, value, traceback)
 
     @property
-    def timeout(self) -> float | None:
+    def timeout(self) -> float:
         """Return the socket timeout."""
         return self._socket.gettimeout()
 

--- a/rcon/client.py
+++ b/rcon/client.py
@@ -39,7 +39,7 @@ class BaseClient:
         return self._socket.__exit__(typ, value, traceback)
 
     @property
-    def timeout(self) -> float:
+    def timeout(self) -> float | None:
         """Return the socket timeout."""
         return self._socket.gettimeout()
 

--- a/rcon/exceptions.py
+++ b/rcon/exceptions.py
@@ -27,3 +27,7 @@ class UserAbort(Exception):
 
 class WrongPassword(Exception):
     """Indicates a wrong password."""
+
+
+class UnexpectedTerminator(Exception):
+    """Indicates an unexpected terminator in the response."""

--- a/rcon/source/proto.py
+++ b/rcon/source/proto.py
@@ -8,7 +8,7 @@ from logging import getLogger
 from random import randint
 from typing import IO, NamedTuple
 
-from rcon.exceptions import EmptyResponse
+from rcon.exceptions import EmptyResponse, UnexpectedTerminator
 
 
 __all__ = ["LittleEndianSignedInt32", "Type", "Packet", "random_request_id"]
@@ -118,7 +118,9 @@ class Packet(NamedTuple):
         return size + payload
 
     @classmethod
-    async def aread(cls, reader: StreamReader, raise_unexpected_terminator: bool = False) -> Packet:
+    async def aread(
+        cls, reader: StreamReader, raise_unexpected_terminator: bool = False
+    ) -> Packet:
         """Read a packet from an asynchronous file-like object."""
         LOGGER.debug("Reading packet asynchronously.")
         size = await LittleEndianSignedInt32.aread(reader)
@@ -138,7 +140,7 @@ class Packet(NamedTuple):
 
         if terminator != TERMINATOR:
             if raise_unexpected_terminator:
-                raise ValueError("Unexpected terminator")
+                raise UnexpectedTerminator(terminator)
             LOGGER.warning("Unexpected terminator: %s", terminator)
 
         return cls(id_, type_, payload, terminator)
@@ -164,7 +166,7 @@ class Packet(NamedTuple):
 
         if terminator != TERMINATOR:
             if raise_unexpected_terminator:
-                raise ValueError("Unexpected terminator")
+                raise UnexpectedTerminator(terminator)
             LOGGER.warning("Unexpected terminator: %s", terminator)
 
         return cls(id_, type_, payload, terminator)

--- a/rcon/source/proto.py
+++ b/rcon/source/proto.py
@@ -118,7 +118,7 @@ class Packet(NamedTuple):
         return size + payload
 
     @classmethod
-    async def aread(cls, reader: StreamReader) -> Packet:
+    async def aread(cls, reader: StreamReader, raise_unexpected_terminator: bool = False) -> Packet:
         """Read a packet from an asynchronous file-like object."""
         LOGGER.debug("Reading packet asynchronously.")
         size = await LittleEndianSignedInt32.aread(reader)
@@ -137,12 +137,14 @@ class Packet(NamedTuple):
         LOGGER.debug("  => terminator: %s", terminator)
 
         if terminator != TERMINATOR:
+            if raise_unexpected_terminator:
+                raise ValueError("Unexpected terminator")
             LOGGER.warning("Unexpected terminator: %s", terminator)
 
         return cls(id_, type_, payload, terminator)
 
     @classmethod
-    def read(cls, file: IO) -> Packet:
+    def read(cls, file: IO, raise_unexpected_terminator: bool = False) -> Packet:
         """Read a packet from a file-like object."""
         LOGGER.debug("Reading packet.")
         size = LittleEndianSignedInt32.read(file)
@@ -161,6 +163,8 @@ class Packet(NamedTuple):
         LOGGER.debug("  => terminator: %s", terminator)
 
         if terminator != TERMINATOR:
+            if raise_unexpected_terminator:
+                raise ValueError("Unexpected terminator")
             LOGGER.warning("Unexpected terminator: %s", terminator)
 
         return cls(id_, type_, payload, terminator)


### PR DESCRIPTION
This PR adds an optional parameter to the rcon functions to raise an UnexpectedTerminator error in the event that a response contains an unexpected terminator.

The reason for this PR is because sometimes we do not want to get a partially completed response string with no way to know that an unexpected terminator has occurred, instead we want either the whole response or an error to be raised.