### PR TITLE
fix bug in async rcon

### DIFF
--- a/rcon/source/async_rcon.py
+++ b/rcon/source/async_rcon.py
@@ -5,7 +5,6 @@ from asyncio import StreamReader, StreamWriter, open_connection, wait_for
 from rcon.exceptions import SessionTimeout, WrongPassword
 from rcon.source.proto import Packet, Type
 
-
 __all__ = ["rcon"]
 
 
@@ -77,7 +76,7 @@ async def rcon(
         raise WrongPassword()
 
     request = Packet.make_command(command, *arguments, encoding=encoding)
-    response = await communicate(reader, writer, request, raise_unexpected_terminator)
+    response = await communicate(reader, writer, request, raise_unexpected_terminator=raise_unexpected_terminator)
     await close(writer)
 
     if enforce_id and response.id != request.id:

--- a/rcon/source/async_rcon.py
+++ b/rcon/source/async_rcon.py
@@ -5,6 +5,7 @@ from asyncio import StreamReader, StreamWriter, open_connection, wait_for
 from rcon.exceptions import SessionTimeout, WrongPassword
 from rcon.source.proto import Packet, Type
 
+
 __all__ = ["rcon"]
 
 


### PR DESCRIPTION
#31 introduced a `TypeError` in the async side of the rcon module.

<details>
<summary>Traceback</summary>

```py
Traceback (most recent call last):
  File "/app/.venv/lib/python3.12/site-packages/discord/ext/commands/core.py", line 235, in wrapped
    ret = await coro(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/extensions/private/minecraft.py", line 45, in minecraft
    output = await rcon(
             ^^^^^^^^^^^
  File "/app/.venv/lib/python3.12/site-packages/rcon/source/async_rcon.py", line 80, in rcon
    response = await communicate(reader, writer, request, raise_unexpected_terminator)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: communicate() takes 3 positional arguments but 4 were given
```

</details>

This PR corrects that by correctly using the keyword-argument as implemented previously.

I am unsure if this bug is present elsewhere in the codebase, as I only use the async side of things and at a glance I don't see any more runtime issues, but if it helps you can run tools like `pyright` or `mypy` to check types correctly to catch things like in future. :)