### PR TITLE
Fixed a bug in the receive_transaction method that ensures the correct termination of the loop.

### DIFF
--- a/rcon/battleye/client.py
+++ b/rcon/battleye/client.py
@@ -77,6 +77,8 @@ class Client(BaseClient, socket_type=SOCK_DGRAM):
             if isinstance(response, CommandResponse):
                 command_responses.append(response)
                 seq = response.seq
+                if len(command_responses) >= seq:
+                    break
                 continue
 
             if isinstance(response, ServerMessage):
@@ -85,8 +87,6 @@ class Client(BaseClient, socket_type=SOCK_DGRAM):
                 if login_response is not None:
                     return login_response
 
-                if len(command_responses) >= seq:
-                    break
 
         return "".join(
             command_response.message


### PR DESCRIPTION
**Problem Description:**
In the receive_transaction method, there was a bug related to the fact that the loop did not terminate properly if the required number of responses was not reached after receiving the CommandResponse. As a result, the method could get stuck in an infinite loop.

**Fix:**
I made changes to the structure of the command response check to ensure that the method terminates execution when the number of received responses (command_responses) reaches the value of seq from the last CommandResponse.

**Changes:**
I moved the exit check for the loop after adding the CommandResponse to the command_responses list and before returning the result.

**Code Before Improvement:**
```python
if isinstance(response, CommandResponse):
    command_responses.append(response)
    seq = response.seq
    continue

if isinstance(response, ServerMessage):
    self.handle_server_message(response)

    if login_response is not None:
        return login_response

    if len(command_responses) >= seq:
        break
```
**Code after correction:**
```python
if isinstance(response, CommandResponse):
    command_responses.append(response)
    seq = response.seq
    if len(command_responses) >= seq:
        break
    continue

```
**Testing:**
I tested the changes in the local environment and confirmed that the issue has been resolved, and the method completes execution in the expected cases. All existing tests also passed successfully.