### PR TITLE
Fix ServerMessageAck to prepend BE header to the ack packet

### DIFF
--- a/rcon/battleye/proto.py
+++ b/rcon/battleye/proto.py
@@ -172,7 +172,8 @@ class ServerMessageAck(NamedTuple):
     seq: int
 
     def __bytes__(self):
-        return bytes(self.header) + self.payload
+        # Correct: prepend BE header (0x42, 0x45) to the ack packet
+        return b"BE" + bytes(self.header) + self.payload
 
     @property
     def header(self) -> Header:


### PR DESCRIPTION
During the execution of the current development status with the following chunk:

```python
from rcon.battleye import Client, ServerMessage

def my_message_handler(server_message: ServerMessage) -> None:
    print('[SERVER MESSAGE]', server_message)

with Client('127.0.0.1', 2412, passwd='xxx', message_handler=my_message_handler) as client:
    client.connect()
    response = client.run('players')

print(response)
```

Generates the following output (aborted due to a stuck sequence)

``` bash
[SERVER MESSAGE] ServerMessage(header=Header(crc32=1129245645, type=2), seq=0, payload=b'RCon admin #0 (127.0.0.1:42432) logged in')
^CTraceback (most recent call last):
  File "/home/dayz/rcon_mini_test.py", line 8, in <module>
    response = client.run('players')
               ^^^^^^^^^^^^^^^^^^^^^
  File "/home/dayz/rcon/rcon/battleye/client.py", line 112, in run
    return self.communicate(CommandRequest.from_command(command, *args))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dayz/rcon/rcon/battleye/client.py", line 101, in communicate
    return self.receive_transaction()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dayz/rcon/rcon/battleye/client.py", line 71, in receive_transaction
    response = self.receive()
               ^^^^^^^^^^^^^^
  File "/home/dayz/rcon/rcon/battleye/client.py", line 60, in receive
    (data := self._socket.recv(self.max_length))[:HEADER_SIZE]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyboardInterrupt
```

After changing the proto script, it runs as expected.

``` bash
[SERVER MESSAGE] ServerMessage(header=Header(crc32=1663007482, type=2), seq=0, payload=b'RCon admin #0 (127.0.0.1:45097) logged in')
[SERVER MESSAGE] ServerMessage(header=Header(crc32=1663007482, type=2), seq=0, payload=b'RCon admin #0 (127.0.0.1:45097) logged in')
Players on server:
[#] [IP Address]:[Port] [Ping] [GUID] [Name]
--------------------------------------------------
```
